### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "express-validator": "^7.3.0",
     "moment-timezone": "^0.5.43",
     "mongodb": "^6.15.0",
-    "mongoose": "^8.12.1"
+    "mongoose": "^8.12.1",
+    "express-rate-limit": "^8.3.2"
   },
   "devDependencies": {
     "@babel/node": "^7.22.5"

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ import bcrypt from "bcrypt";
 import listEndpoints from "express-list-endpoints";
 import moment from 'moment-timezone';
 import { body, validationResult } from 'express-validator';
+import rateLimit from "express-rate-limit";
 
 const mongoUrl = process.env.MONGO_URL || "mongodb://127.0.0.1:27017/final-project-api";
 mongoose.connect(mongoUrl, { useNewUrlParser: true, useUnifiedTopology: true });
@@ -153,8 +154,13 @@ const Treatment = mongoose.model("Treatment", TreatmentSchema);
 })();
 
 
+const treatmentsRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per window
+});
+
 // GET 
-app.get(PATHS.treatments, async (_, res) => {
+app.get(PATHS.treatments, treatmentsRateLimiter, async (_, res) => {
   try {
     const treatments = await Treatment.find(); // Retrieve all treatments
     res.status(200).json({


### PR DESCRIPTION
Potential fix for [https://github.com/smirrebinx/project-final-project-api-backend/security/code-scanning/2](https://github.com/smirrebinx/project-final-project-api-backend/security/code-scanning/2)

Add rate-limiting middleware and apply it to the `PATHS.treatments` GET route so requests hitting `Treatment.find()` are throttled.

Best fix without changing functionality:
1. Import `express-rate-limit`.
2. Define a limiter instance near route setup (e.g., 100 requests per 15 minutes per IP).
3. Attach that limiter to the specific route: `app.get(PATHS.treatments, treatmentsLimiter, async ...)`.

This preserves current response behavior for normal traffic while mitigating abuse.  
Changes needed only in `server.js`:
- Add one import line.
- Add limiter definition before the GET route.
- Update the route signature to include the limiter middleware.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
